### PR TITLE
Update link to Data Package Manager - old link is deprecated

### DIFF
--- a/docs/data-packages/publish-tabular.md
+++ b/docs/data-packages/publish-tabular.md
@@ -62,7 +62,7 @@ Format][sdf] specs.
 [creator]: https://create.frictionlessdata.io/
 [JSON]: http://en.wikipedia.org/wiki/JSON
 [dp]: http://datahub.io/docs/data-packages
-[dpm]:  https://github.com/okfn/dpm
+[dpm]:  https://datahub.io/docs/features/data-cli
 [sdf]: /docs/data-packages/tabular
 
 ### 4. Put the data package online


### PR DESCRIPTION
Updating link on Option 3, it was pointing to a Deprecated tool, now is pointing to the Data CLI Tool on https://datahub.io/docs/features/data-cli

> **Option 3:*** Use our [Data Package Manager][dpm] tool for the command line if you are comfortable with that interface (requires node.js).

